### PR TITLE
Add VisualSentimentCNN CoreML model

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Reference: [Epinions.com reviews dataset](http://boston.lti.cs.cmu.edu/classes/9
 Example: [SentimentCoreMLDemo](https://github.com/cocoa-ai/SentimentCoreMLDemo)
 
 ### VisualSentimentCNN
-Model: [VisualSentimentCNN](https://drive.google.com/open?id=0B1ghKa_MYL6meTZRT3U5b0o5amc)
+Model: [VisualSentimentCNN](https://drive.google.com/open?id=0B1ghKa_MYL6mZ0dITW5uZlgyNTg)
 
 Description: Visual Sentiment Prediction
 

--- a/README.md
+++ b/README.md
@@ -77,3 +77,14 @@ Author: [Vadym Markov](https://github.com/vadymmarkov)
 Reference: [Epinions.com reviews dataset](http://boston.lti.cs.cmu.edu/classes/95-865-K/HW/HW3/)
 
 Example: [SentimentCoreMLDemo](https://github.com/cocoa-ai/SentimentCoreMLDemo)
+
+### VisualSentimentCNN
+Model: [VisualSentimentCNN](https://drive.google.com/open?id=0B1ghKa_MYL6meTZRT3U5b0o5amc)
+
+Description: Visual Sentiment Prediction
+
+Author: [Image Processing Group - BarcelonaTECH - UPC](https://github.com/imatge-upc)
+
+Reference: [From Pixels to Sentiment: Fine-tuning CNNs for Visual Sentiment Prediction](https://github.com/imatge-upc/sentiment-2017-imavis)
+
+Example: [SentimentVisionDemo](https://github.com/cocoa-ai/SentimentVisionDemo)


### PR DESCRIPTION
This PR adds `VisualSentimentCNN` for visual sentiment prediction from https://github.com/cocoa-ai/SentimentVisionDemo